### PR TITLE
Sérialisation des commentaires, images, documents et votes

### DIFF
--- a/documentation/API.md
+++ b/documentation/API.md
@@ -173,10 +173,6 @@ id | Identifiant du lieu | 57dbe334c3eaf116f88e0318
 
 Nom | Description | Exemple | Absence
 ----|-------------|---------|--------
-comms | Nombre de commentaires à transmettre | 10 | Aucun
-pics | Nombre de photos à*\* transmettre | 5 | Aucun
-docs | Nombre de documents à transmettre | 5 | Aucun
-votes | Nombre de votes à transmettre | 2 | Aucun
 admin | Récupérer des informations administrateur | true | false
 
 #### Charge
@@ -199,10 +195,6 @@ isVerified | État de vérification du lieu | true
 *description* | Description | "Maison de la Recherche et de l’Imagination"
 *startDate* | Date de création | "2015-01-01T13:00:00.000Z"
 *endDate* | Date de suppression | "2016-09-09T08:00:00.000Z"
-*comments* | Commentaires | *Liste de commentaires*
-*pictures* | Photos | *Liste de photos*
-*documents* | Documents | *Liste de documents*
-*votes* | Votes | *Liste de votes*
 *moderateComments*\* | Modération des commentaires | true
 *moderatePictures*\* | Modération des photos | true
 *moderateDocuments*\* | Modération des documents | true

--- a/models/comment.js
+++ b/models/comment.js
@@ -1,0 +1,19 @@
+/**
+ * Model for comments
+ */
+
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var commentSchema = new Schema({
+  place: { type: Schema.Types.ObjectId, required: true },
+  author: { type: Schema.Types.ObjectId, required: true },
+  date: { type: Date, default: Date.now, required: true },
+  content: { type: String, required: true }
+});
+
+var Comment = mongoose.model('Comment', commentSchema);
+
+module.exports = Comment;
+
+/* vim: set ts=2 sw=2 et si colorcolumn=80 : */

--- a/models/document.js
+++ b/models/document.js
@@ -9,7 +9,7 @@ var documentSchema = new Schema({
   place: { type: Schema.Types.ObjectId, required: true },
   author: { type: Schema.Types.ObjectId, required: true },
   date: { type: Date, default: Date.now, required: true },
-  type: { type: String, required: true }
+  type: { type: String, required: true },
   url: { type: String, required: true }
 });
 

--- a/models/document.js
+++ b/models/document.js
@@ -1,16 +1,20 @@
 /**
- * Picture schema
+ * Model for documents
  */
 
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
-var pictureSchema = new Schema({
+var documentSchema = new Schema({
+  place: { type: Schema.Types.ObjectId, required: true },
   author: { type: Schema.Types.ObjectId, required: true },
   date: { type: Date, default: Date.now, required: true },
+  type: { type: String, required: true }
   url: { type: String, required: true }
 });
 
-module.exports = pictureSchema;
+var Document = mongoose.model('Document', documentSchema);
+
+module.exports = Document;
 
 /* vim: set ts=2 sw=2 et si colorcolumn=80 : */

--- a/models/picture.js
+++ b/models/picture.js
@@ -1,16 +1,19 @@
 /**
- * Comment schema
+ * Model for pictures
  */
 
 var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
-var commentSchema = new Schema({
+var pictureSchema = new Schema({
+  place: { type: Schema.Types.ObjectId, required: true },
   author: { type: Schema.Types.ObjectId, required: true },
   date: { type: Date, default: Date.now, required: true },
-  content: { type: String, required: true }
+  url: { type: String, required: true }
 });
 
-module.exports = commentSchema;
+var Picture = mongoose.model('Picture', pictureSchema);
+
+module.exports = Picture;
 
 /* vim: set ts=2 sw=2 et si colorcolumn=80 : */

--- a/models/place.js
+++ b/models/place.js
@@ -6,8 +6,6 @@ var mongoose = require('mongoose');
 var Schema = mongoose.Schema;
 
 var locationSchema = require('./schemas/location');
-var commentSchema = require('./schemas/comment');
-var pictureSchema = require('./schemas/picture');
 
 var placeSchema = new Schema({
   location: {type: locationSchema, required: true },
@@ -19,10 +17,6 @@ var placeSchema = new Schema({
   description: String,
   startDate: { type: Date, default: Date.now },
   endDate: Date,
-  comments: [commentSchema],
-  pictures: [pictureSchema],
-  documents: [], // TODO: documentSchema
-  votes: [String],
   moderateComments: Boolean,
   moderatePictures: Boolean,
   moderateDocuments: Boolean,
@@ -38,13 +32,7 @@ placeSchema.statics.onSaved = function (res, next) {
   return function (error, savedPlace) {
     if (error) return next(error);
 
-    // Remove unwanted info
     savedPlace.__v = undefined;
-    savedPlace.comments = undefined;
-    savedPlace.pictures = undefined;
-    savedPlace.documents = undefined;
-    savedPlace.votes = undefined;
-
     res.status(201).json(savedPlace);
   };
 };

--- a/models/place.js
+++ b/models/place.js
@@ -25,18 +25,6 @@ var placeSchema = new Schema({
   denyDocuments: Boolean
 });
 
-/**
- * Create a callback function
- */
-placeSchema.statics.onSaved = function (res, next) {
-  return function (error, savedPlace) {
-    if (error) return next(error);
-
-    savedPlace.__v = undefined;
-    res.status(201).json(savedPlace);
-  };
-};
-
 var Place = mongoose.model('Place', placeSchema);
 
 module.exports = Place;

--- a/models/vote.js
+++ b/models/vote.js
@@ -1,0 +1,19 @@
+/**
+ * Model for votes
+ */
+
+var mongoose = require('mongoose');
+var Schema = mongoose.Schema;
+
+var voteSchema = new Schema({
+  place: { type: Schema.Types.ObjectId, required: true },
+  author: { type: Schema.Types.ObjectId, required: true },
+  date: { type: Date, default: Date.now, required: true },
+  url: { type: String, required: true }
+});
+
+var Vote = mongoose.model('Vote', voteSchema);
+
+module.exports = Vote;
+
+/* vim: set ts=2 sw=2 et si colorcolumn=80 : */

--- a/modules/utils.js
+++ b/modules/utils.js
@@ -1,0 +1,23 @@
+/**
+ * Utilitaries module
+ */
+
+function Utils() {
+  this.returnEntity = Utils.returnEntity;
+}
+
+/**
+ * Creates a callback to return an entity after a database action
+ */
+Utils.returnEntity = function (res, next, status = 200) {
+  return function (error, entity) {
+    if (error) return next(error);
+
+    entity.__v = undefined;
+    res.status(status).json(entity);
+  };
+};
+
+module.exports = Utils;
+
+/* vim: set ts=2 sw=2 et si colorcolumn=80 : */

--- a/routes/places.js
+++ b/routes/places.js
@@ -2,6 +2,7 @@ var express = require('express');
 var mongoose = require('mongoose');
 
 var Checks = require('../modules/checks');
+var Utils = require('../modules/utils');
 
 var Place = require('../models/place');
 var Comment = require('../models/comment');
@@ -115,14 +116,13 @@ function getPlacesHeaders(req, res, next) {
     headerPhoto: true
   };
 
-  Place.find(filter, projection,
-    function returnPlacesHeaders(error, placesHeaders) {
-      if (error) return next(error);
-      res.json(placesHeaders);
-    });
+  var returnPlacesHeaders = Utils.returnEntity(res, next);
+  
+  Place.find(filter, projection, returnPlacesHeaders);
 }
 
 
+// TODO: Modifier
 function getPlaceInfo(req, res, next) {
   var place = req.place;
   
@@ -263,12 +263,8 @@ function createPlace(req, res, next) {
   var place = new Place(req.body);
 
   if (!req.body.setHeaderPhoto) {
-    place.save(function onPlaceSaved(error, savedPlace) {
-      if (error) return next(error);
-      
-      savedPlace.__v = undefined;
-      res.status(201).json(savedPlace);
-    });
+    var onPlaceSaved = Utils.returnEntity(res, next, 201);
+    place.save(onPlaceSaved);
   }
   else { 
     place.validate(function onPlaceValidated(error) {
@@ -342,14 +338,13 @@ function getComments(req,res,next) {
     }
   }
   
-  Comment.find({ place: place._id })
+  var returnComments = Utils.returnEntity(res, next);
+  
+  Comment.find({ place: place._id }, { __v: false })
     .sort('-date')
     .skip((page - 1) * n)
     .limit(n)
-    .exec(function returnComments(error, comments) {
-      if (error) return next(error);
-      res.json(comments);
-    });
+    .exec(returnComments);
 }
 
 
@@ -393,14 +388,13 @@ function getPictures(req,res,next) {
     }
   }
 
-  Picture.find({ place: place._id })
+  var returnPictures = Utils.returnEntity(res, next);
+
+  Picture.find({ place: place._id }, { __v: false })
     .sort('-date')
     .skip((page - 1) * n)
     .limit(n)
-    .exec(function returnPictures(error, pictures) {
-      if (error) return next(error);
-      res.json(pictures);
-    });
+    .exec(returnPictures);
 }
 
 

--- a/routes/places.js
+++ b/routes/places.js
@@ -28,7 +28,7 @@ router.post('/:id/pictures', Checks.db, createPicture);
 
 
 function getPlace(req, res, next, id) {
-  Place.findById(id, function onPlaceFound(error, place) {
+  Place.findById(id, { __v: false }, function onPlaceFound(error, place) {
     if (error) return next(error);
 
     if (!place) {
@@ -122,7 +122,6 @@ function getPlacesHeaders(req, res, next) {
 }
 
 
-// TODO: Modifier
 function getPlaceInfo(req, res, next) {
   var place = req.place;
   
@@ -148,114 +147,7 @@ function getPlaceInfo(req, res, next) {
     return next(err);
   }
 
-  // TODO: Réécrire pour éviter la redondance de code
-
-  if (req.query.comms) {
-    var nComments = parseInt(req.query.comms);
-
-    if (isNaN(nComments)) {
-      var err = new Error('Bad Request: comms must be an integer');
-      err.status = 400;
-      return next(err);
-    }
-
-    if (nComments <= 0) {
-      var err = new Error('Bad Request: comms must be strictly positive');
-      err.status = 400;
-      return next(err);
-    }
-
-    var projection = {
-      _id: true,
-      // Note: $slice: nb ou $slice: [skip, limit]
-      comments: { $slice: nComments }
-    };
-  }
-
-  if (req.query.pics) {
-    var nPictures = parseInt(req.query.pics);
-
-    if (isNaN(nPictures)) {
-      var err = new Error('Bad Request: pics must be an integer');
-      err.status = 400;
-      return next(err);
-    }
-
-    if (nPictures <= 0) {
-      var err = new Error('Bad Request: pics must be strictly positive');
-      err.status = 400;
-      return next(err);
-    }
-    
-    if (!projection)
-      var projection = { _id: true };
-
-    projection.pictures = { $slice: nPictures };
-  }
-
-  if (req.query.docs) {
-    var nDocuments = parseInt(req.query.docs);
-
-    if (isNaN(nDocuments)) {
-      var err = new Error('Bad Request: docs must be an integer');
-      err.status = 400;
-      return next(err);
-    }
-
-    if (nDocuments <= 0) {
-      var err = new Error('Bad Request: docs must be strictly positive');
-      err.status = 400;
-      return next(err);
-    }
-    
-    if (!projection)
-      var projection = { _id: true };
-
-    projection.documents = { $slice: nDocuments };
-  }
-
-  if (req.query.votes) {
-    var nVotes = parseInt(req.query.votes);
-
-    if (isNaN(nVotes)) {
-      var err = new Error('Bad Request: votes must be an integer');
-      err.status = 400;
-      return next(err);
-    }
-
-    if (nVotes <= 0) {
-      var err = new Error('Bad Request: votes must be strictly positive');
-      err.status = 400;
-      return next(err);
-    }
-    
-    if (!projection)
-      var projection = { _id: true };
-
-    projection.votes = { $slice: nVotes };
-  }
-  
-  if (!projection)
-    return res.json(place); 
-  
-  // Get additional info in the database
-  Place.findById(place._id, projection, function onPlaceInfoGot(error, info) {
-    if (error) return next(error);
-
-    if (info.comments && info.comments.length !== 0)
-      place.comments = info.comments;
-
-    if (info.pictures && info.pictures.length !== 0)
-      place.pictures = info.pictures;
-
-    if (info.documents && info.documents.length !== 0)
-      place.documents = info.documents;
-
-    if (info.votes && info.votes.length !== 0)
-      place.votes = info.votes;
-
-    res.json(place);
-  });
+  res.json(place);
 }
 
 

--- a/routes/places.js
+++ b/routes/places.js
@@ -1,12 +1,18 @@
 var express = require('express');
 var mongoose = require('mongoose');
-var router = express.Router();
+
+var Checks = require('../modules/checks');
+
+var Place = require('../models/place');
+var Comment = require('../models/comment');
+var Picture = require('../models/picture');
+var Document = require('../models/document');
+var Vote = require('../models/vote');
+var PendingUpload = require('../models/pending_upload');
 
 var config = require('../config.json');
 
-var Checks = require('../modules/checks');
-var Place = require('../models/place');
-var PendingUpload = require('../models/pending_upload');
+var router = express.Router();
 
 router.param('id', Checks.isValidObjectId);
 router.param('id', getPlace);
@@ -335,17 +341,14 @@ function getComments(req,res,next) {
       return next(err);
     }
   }
-
-  var projection = { _id: true };
-
-  projection.comments = (n !== 0)
-    ? { $slice: [(page - 1) * n, n] }
-    : true;
   
-  Place.findById(place._id, projection,
-    function returnComments(error, result) {
+  Comment.find({ place: place._id })
+    .sort('-date')
+    .skip((page - 1) * n)
+    .limit(n)
+    .exec(function returnComments(error, comments) {
       if (error) return next(error);
-      res.json(result.comments);
+      res.json(comments);
     });
 }
 
@@ -390,16 +393,13 @@ function getPictures(req,res,next) {
     }
   }
 
-  var projection = { _id: true };
-
-  projection.pictures = (n !== 0)
-    ? { $slice: [(page - 1) * n, n] }
-    : true;
-  
-  Place.findById(place._id, projection,
-    function returnPictures(error, result) {
+  Picture.find({ place: place._id })
+    .sort('-date')
+    .skip((page - 1) * n)
+    .limit(n)
+    .exec(function returnPictures(error, pictures) {
       if (error) return next(error);
-      res.json(result.pictures);
+      res.json(pictures);
     });
 }
 

--- a/routes/places.js
+++ b/routes/places.js
@@ -180,10 +180,22 @@ function createPlace(req, res, next) {
 
 
 function deletePlace(req, res, next) {
-  req.place.remove(function onPlaceRemoved(error) {
+  var place = req.place;
+
+  Comment.remove({ place: place._id }, onRemoved);
+  Picture.remove({ place: place._id }, onRemoved);
+  Document.remove({ place: place._id }, onRemoved);
+  Vote.remove({ place: place._id }, onRemoved);
+
+  // TODO: Meilleure gestion (pour l’instant seule la première erreur
+  // déclenchée est retournée
+  function onRemoved(error) {
+    if (error) return next(error);
+  }
+
+  place.remove(function onPlaceRemoved(error) {
     if (error) return next(error);
 
-    // TODO: Supprimer les entités liées (Comments, Pictures, Documents, Votes)
     // TODO: Supprimer les fichiers liés (headerPhoto, photos, documents, …)
 
     res.status(204).end();

--- a/routes/places.js
+++ b/routes/places.js
@@ -406,18 +406,16 @@ function getPictures(req,res,next) {
 
 function createPicture(req, res, next) {
   var place = req.place;
-
-  var pictureInfo = {
+  
+  // Not a Picture object in order to get the real timestamp on picture upload
+  var picture = {
     place: place._id,
-    picture: {
-      // TODO: Mettre le véritable auteur
-      author: mongoose.Types.ObjectId("57dbe334c3eaf116f88eca27")
-    }
+    author: mongoose.Types.ObjectId("57dbe334c3eaf116f88eca27")
   };
 
   var pendingUpload = new PendingUpload({
-    contentType: 'picture-info',
-    content: pictureInfo
+    contentType: 'picture',
+    content: picture
   });
   pendingUpload.save(sendUploadURL);
 

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -91,8 +91,12 @@ function upload(req, res, next) {
         var place = new Place(pendingUpload.content);
         place.headerPhoto = url;
 
-        var onPlaceSaved = Place.onSaved(res, next);
-        place.save(onPlaceSaved);
+        place.save(function onPlaceSaved(error, savedPlace) {
+          if (error) return next(error);
+          
+          savedPlace.__v = undefined;
+          res.status(201).json(savedPlace);
+        });
 
       case 'picture-info':
         var picture = pendingUpload.content.picture;

--- a/routes/upload.js
+++ b/routes/upload.js
@@ -4,6 +4,7 @@ var fileType = require('file-type');
 var uuid = require('uuid');
 
 var Checks = require('../modules/checks');
+var Utils = require('../modules/utils');
 
 var PendingUpload = require('../models/pending_upload');
 var FileSaver = require('../modules/filesaver');
@@ -97,24 +98,15 @@ function upload(req, res, next) {
         var place = new Place(pendingUpload.content);
         place.headerPhoto = url;
 
-        place.save(function onPlaceSaved(error, savedPlace) {
-          if (error) return next(error);
-          
-          savedPlace.__v = undefined;
-          res.status(201).json(savedPlace);
-        });
+        var onPlaceSaved = Utils.returnEntity(res, next, 201);
+        place.save(onPlaceSaved);
 
       case 'picture':
         var picture = new Picture(pendingUpload.content);
         picture.url = url;
 
-        // TODO: Factoriser le code
-        picture.save(function onPictureSaved(error, savedPicture) {
-          if (error) return next(error);
-
-          savedPicture.__v = undefined;
-          res.status(201).json(savedPicture);
-        });
+        var onPictureSaved = Utils.returnEntity(res, next, 201);
+        picture.save(onPictureSaved);
     }
   }
 }


### PR DESCRIPTION
Je propose dans ce pull request un changement d’une partie de l’architecture de données :
- l’entité `Place` n’a plus d’attributs `comments`, `pictures`, `documents` ou `votes`,
- des entités `Comment`, `Picture`, `Document` et `Vote` existent désormais, avec un attribut `place` permettant de les lier à un lieu via son `_id`.

Les avantages de cette nouvelle architecture sont :
- la simplification d’une grande partie du code (plus de requêtes à faire sur des sous-documents),
- l’amélioration de la sécurité (faire des requêtes directement sur des sous-documents via `mongoose` impliquait de ne pas pouvoir utiliser les validations)
- l’amélioration des performances (faire une recherche dans un tableau de sous-documents est plus long que de faire une recherche dans une collection).

L’utilisation de sous-documents dans MongoDB est en fait prévue pour des sous-documents peu nombreux et qui ne changent pas souvent mais qui sont systématiquement demandés en même temps que le document (ex : plusieurs dates pour un événement). Les commentaires, images, documents et votes sont demandés par pages et non dans leur intégralité, et de nouveaux éléments seront ajoutés régulièrement, donc une sérialisation est indispensable.

Si vous avez la moindre question, dites-moi. Je ne fusionnerai pas ce pull request sans en avoir discuté de vive voix avec vous tous au préalable (et ça n’empêche pas de travailler sur autre chose en attendant, tout l’intérêt des branches est là).
