### PR TITLE
Limitation du nombre de requêtes API

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,10 @@ var supervisor = new Supervisor(config.supervisor);
 var app = express();
 app.enable('strict routing');
 
+// If the app runs in production mode, it is behind a reverse proxy. Trust it.
+if (app.get('env') === 'production')
+  app.enable('trust proxy');
+
 // Modules
 app.use(logger('dev'));
 

--- a/config.json.sample
+++ b/config.json.sample
@@ -10,6 +10,11 @@
     "pendingUploadsValidity": 60
   },
 
+  "rateLimiter": {
+    "windowSize": 60,
+    "max": 100
+  },
+
   "auth": {
     "secret": "<Set a strong secret, e.g. 32 random Bytes in base64>",
     "tokenValidity": 86400

--- a/config.json.sample
+++ b/config.json.sample
@@ -13,6 +13,10 @@
   "rateLimiter": {
     "windowSize": 60,
     "max": 100,
+    "registration": {
+      "windowSizeMin": 10,
+      "max": 10
+    },
     "login": {
       "windowSizeMin": 15,
       "max": 5

--- a/config.json.sample
+++ b/config.json.sample
@@ -12,7 +12,11 @@
 
   "rateLimiter": {
     "windowSize": 60,
-    "max": 100
+    "max": 100,
+    "login": {
+      "windowSizeMin": 15,
+      "max": 5
+    }
   },
 
   "auth": {

--- a/documentation/Configuration.md
+++ b/documentation/Configuration.md
@@ -6,6 +6,7 @@
 * [**Description des attributs**](#description-des-attributs)
     * [Configuration générale](#configuration-générale)
     * [MongoDB](#mongodb)
+    * [Limitation des appels API](#limitation-des-appels-api)
     * [Système d’autorisation (jetons)](#système-dautorisation-jetons)
     * [Stockage de fichiers](#stockage-de-fichiers)
 
@@ -62,6 +63,65 @@ Si aucun paramètre n’est à renseigner, cet attribut attend un objet vide `{}
   }
 }
 ```
+
+### Limitation des appels API
+
+Pour éviter un usage frauduleux de l’API — bourrage de données, inscriptions en masse ou tentatives de connexion par force brute —, les appels API sont limités à plusieurs niveaux.
+
+Le fonctionnement du limiteur d’appels est basé sur un principe simple :
+
+* une fenêtre coulissante dont la durée est paramétrable,
+* un nombre d’appels maximum dans cette fenêtre.
+
+Le limiteur de tentatives de connexion ajoute une sécurité supplémentaire : après un premier appel sans délais, les réponses suivantes sont retardées de deux secondes supplémentaires jusqu’à épuiser le nombre d’essais dans la fenêtre.
+
+#### `rateLimiter.windowSize`
+
+* **Type :** Number
+
+Taille de la fenêtre pour les requêtes API en général, **en secondes**.
+
+**Exemple :** `60`
+
+#### `rateLimiter.max`
+
+* **Type :** Number
+
+Nombre maximum de requêtes API en général dans la fenêtre.
+
+**Exemple :** `100`
+
+#### `rateLimiter.registration.windowSizeMin`
+
+* **Type :** Number
+
+Taille de la fenêtre pour la requête de création de compte, **en minutes**.
+
+**Exemple :** `10`
+
+#### `rateLimiter.registration.max`
+
+* **Type :** Number
+
+Nombre maximum de requêtes de connection dans la fenêtre.
+
+**Exemple :** `10`
+
+#### `rateLimiter.login.windowSizeMin`
+
+* **Type :** Number
+
+Taille de la fenêtre pour les tentatives de connexion, **en minutes**.
+
+**Exemple :** `15`
+
+#### `rateLimiter.max`
+
+* **Type :** Number
+
+Nombre de tentitives de connexion dans la fenêtre.
+
+**Exemple :** `5`
 
 ### Système d’autorisation (jetons)
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "debug": "~2.2.0",
     "express": "~4.13.4",
     "express-jwt": "^5.0.0",
+    "express-rate-limit": "^2.6.0",
     "express-slash": "^2.0.1",
     "file-type": "^3.8.0",
     "jsonwebtoken": "^7.1.9",

--- a/routes/api_v1.js
+++ b/routes/api_v1.js
@@ -2,6 +2,7 @@ var express = require('express');
 var bodyParser = require('body-parser');
 var passport = require('passport');
 var LocalStrategy = require('passport-local').Strategy;
+var RateLimit = require('express-rate-limit');
 
 var Auth = require('../modules/auth');
 
@@ -12,12 +13,24 @@ var routes = require('./api_v1/routes');
 var abuseReports = require('./api_v1/abuse_reports');
 var upload = require('./api_v1/upload');
 
+var config = require('../config.json');
+
 var router = express.Router({ strict: true });
+
+// Rate limiter
+var apiLimiter = new RateLimit({
+  windowMs: config.rateLimiter.windowSize * 1000,
+  max: config.rateLimiter.max,
+  delayMs: 0,
+});
 
 // Passport for authentication
 passport.use(new LocalStrategy(Auth.verify));
 
 // Modules
+router.use(apiLimiter);
+router.use(passport.initialize());
+router.use(Auth.jwt);
 router.use(bodyParser.json());
 router.use(bodyParser.raw({ type: 'image/jpeg', limit: '5MB' }));
 router.use(bodyParser.raw({ type: 'image/png', limit: '5MB' }));
@@ -26,8 +39,6 @@ router.use(bodyParser.raw({ type: 'application/pdf', limit: '10MB' }));
 router.use(bodyParser.raw({ type: 'application/msword', limit: '5MB' }));
 router.use(bodyParser.raw({ type: 'application/vnd.oasis.opendocument.text',
   limit: '5MB' }));
-router.use(passport.initialize());
-router.use(Auth.jwt);
 
 // Routes
 router.use('/', index);

--- a/routes/api_v1/index.js
+++ b/routes/api_v1/index.js
@@ -11,19 +11,29 @@ var config = require('../../config.json');
 
 var router = express.Router({ strict: true });
 
+// Registration rate limiter
+var registrationWs = config.rateLimiter.registration.windowSizeMin;
+var registrationLimiter = new RateLimit({
+  windowMs: registrationWs * 60 * 1000,
+  max: config.rateLimiter.registration.max,
+  delayMs: 0,
+  message: 'Too many registrations from this IP. Please retry in '
+    + registrationWs + ' minutes'
+});
+
 // Login rate limiter
-var ws = config.rateLimiter.login.windowSizeMin;
+var loginWs = config.rateLimiter.login.windowSizeMin;
 var loginLimiter = new RateLimit({
-  windowMs: ws * 60 * 1000,
+  windowMs: loginWs * 60 * 1000,
   delayAfter: 1,
   delayMs: 2 * 1000,
   max: config.rateLimiter.login.max,
-  message: 'Too many login attemps from this IP. Please retry in ' + ws
+  message: 'Too many login attemps from this IP. Please retry in ' + loginWs
     + ' minutes'
 });
 
 router.get('/', getRoot);
-router.post('/register', Checks.db, register, sendToken);
+router.post('/register', registrationLimiter, Checks.db, register, sendToken);
 router.post('/login', loginLimiter, Checks.db, login, sendToken);
 
 

--- a/routes/api_v1/index.js
+++ b/routes/api_v1/index.js
@@ -1,16 +1,30 @@
 var express = require('express');
 var passport = require('passport');
+var RateLimit = require('express-rate-limit');
 
 var Checks = require('../../modules/checks');
 var Auth = require('../../modules/auth');
 
 var User = require('../../models/user');
 
+var config = require('../../config.json');
+
 var router = express.Router({ strict: true });
+
+// Login rate limiter
+var ws = config.rateLimiter.login.windowSizeMin;
+var loginLimiter = new RateLimit({
+  windowMs: ws * 60 * 1000,
+  delayAfter: 1,
+  delayMs: 2 * 1000,
+  max: config.rateLimiter.login.max,
+  message: 'Too many login attemps from this IP. Please retry in ' + ws
+    + ' minutes'
+});
 
 router.get('/', getRoot);
 router.post('/register', Checks.db, register, sendToken);
-router.post('/login', Checks.db, login, sendToken);
+router.post('/login', loginLimiter, Checks.db, login, sendToken);
 
 
 function getRoot(req, res, next) {


### PR DESCRIPTION
Introduit la limitation du nombre d’appels API ainsi que sa configuration à trois niveaux :

* appels API en général,
* requête de création de compte,
* requête de connexion.